### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,31 @@
+name: Go
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ['1.24', '1.25']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v -race ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Format check
+        run: test -z "$(gofmt -l .)"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/go.yml` with CI pipeline for Go build, test, vet, and format checks
- Matrix build against Go 1.24 and 1.25 (updated from the original 1.22/1.23 since `go.mod` requires `go 1.25`)
- Runs on push/PR to `main` with read-only permissions

Closes #1

## Test plan
- [ ] Verify workflow appears in the Actions tab after merge
- [ ] Confirm matrix builds pass for both Go 1.24 and 1.25
- [ ] Validate that `gofmt` check correctly catches formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)