### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,20 +3,37 @@ name: Go
 on:
   push:
     branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/go.yml'
   pull_request:
     branches: [main]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - '.github/workflows/go.yml'
 
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         go-version: ['1.24', '1.25']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Standardizes `.github/workflows/go.yml` to the CorvidLabs CI standard.

- Add Go `paths:` filter to push/pull_request (`**/*.go`, `go.mod`, `go.sum`, `Makefile`, `.github/workflows/go.yml`) so README/docs-only changes no longer trigger the build/test/vet/fmt matrix.
- Add `concurrency:` group (`${{ github.workflow }}-${{ github.ref }}`) with `cancel-in-progress: true` to cancel redundant runs.
- Bump `actions/checkout@v4` to `@v5`.
- Add `timeout-minutes: 15` to the build job.
- Runner kept on GitHub-hosted `ubuntu-latest` (correct for a PUBLIC repo).

Mirrors the CorvidLabs/merlin CI standard.